### PR TITLE
delivery_addressテーブル作成及びウィザード形式のマークアップ(下地)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,4 @@
 @import "modules/log";
 @import "modules/signup";
 @import "modules/registration";
+@import "modules/delivery_address"

--- a/app/assets/stylesheets/modules/_delivery_address.scss
+++ b/app/assets/stylesheets/modules/_delivery_address.scss
@@ -1,0 +1,150 @@
+* {
+  box-sizing: border-box;
+}
+
+.delivery_address-wrapper {
+  position: relative;
+  min-height: 100%;
+  background: #f5f5f5;
+  font-family: 'Source Sans Pro', Helvetica , Arial, 'æ¸¸ã‚´ã‚·ãƒƒã‚¯ä½“', 'YuGothic', 'ãƒ¡ã‚¤ãƒªã‚ª', 'Meiryo', sans-serif;
+  font-size: 14px;
+  color: #333;
+  line-height: 1;
+}
+
+.delivery_address-header {
+  height: 128px;
+  -webkit-box-align: center;
+  align-items: center;
+  display: flex;
+  -webkit-box-pack: center;
+  justify-content: center;
+}
+
+.delivery_address-main {
+  display: block;
+}
+
+.delivery_address-container {
+  width: 700px;
+  margin: 0 auto;
+  background: #fff;
+}
+
+.delivery_address-head {
+  font-size: 22px;
+  padding: 32px;
+  line-height: 1.5;
+  text-align: center;
+  font-weight: bold;
+}
+
+.delivery_address-form {
+  padding: 24px 16px 40px;
+  border-top: 1px solid #f5f5f5;
+}
+
+.delivery_address-content {
+  max-width: 343px;
+  margin: 0 auto;
+}
+
+.addlress-form-label {
+  font-weight: 600;
+  display: inline-block;
+  font-size: 14px;
+}
+
+.delivery_address-require {
+  margin: 0 0 0 8px;
+  padding: 2px 4px;
+  border-radius: 2px;
+  color: #fff;
+  font-size: 12px;
+  vertical-align: top;
+  background: #ea352d;
+  &__optionall {
+    margin: 0 0 0 8px;
+    padding: 2px 4px;
+    border-radius: 2px;
+    color: #fff;
+    font-size: 12px;
+    vertical-align: top;
+    background: #ccc;
+  }
+}
+
+.delivery_address-name {
+  display: flex;
+  justify-content: space-between;
+}
+
+.delivery_address-input-default {
+  height: 48px;
+  padding: 10px 16px 8px;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  background: #fff;
+  line-height: 1.5;
+  font-size: 16px;
+  margin: 8px 0 24px 0;
+  width: 100%;
+}
+
+.left-side {
+  margin-right: 8px;
+  width: 50%;
+}
+
+.right-side {
+  width: 50%;
+}
+
+.user_registration-btn {
+  height: 55px;
+  width: 100%;
+  display: inherit;
+  display: inline-block;
+  background-color: #3CCACE;
+  color: white;
+  border: none;
+  margin: 24px 0 0;
+}
+.delivery_address-footer {
+  width: 456px;
+  height: 220px;
+  margin: 0 auto;
+  z-index: 1;
+  padding: 40px 0;
+  text-align: center;
+  display: block;
+}
+
+.terms {
+  margin-bottom: 30px;
+  &__list {
+    display: flex;
+    justify-content: center;
+    list-style: none;
+    font-size: 12px;
+    &__of_use {
+      margin: 0 20px;
+    }
+  }
+}
+
+.terms-link {
+  text-decoration: none;
+  color: #333 !important;
+}
+
+.footer-logo {
+  height: 65px;
+  margin-bottom: 8px;
+  width: 80px;
+  vertical-align: middle;
+}
+
+.company-inc {
+  font-size: 12px;
+}

--- a/app/controllers/delivery_address_controller.rb
+++ b/app/controllers/delivery_address_controller.rb
@@ -1,0 +1,2 @@
+class DeliveryAddressController < ApplicationController
+end

--- a/app/helpers/delivery_address_helper.rb
+++ b/app/helpers/delivery_address_helper.rb
@@ -1,0 +1,2 @@
+module DeliveryAddressHelper
+end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,0 +1,10 @@
+class DeliveryAddress < ApplicationRecord
+  belongs_to :user, optional: true
+  validates :delivery_family_name, :delivery_first_name, :delivery_family_name_kana, :delivery_first_name_kana, :post_code, :city, :home_number, presence: true
+  validates :post_code, format: {/^\d{3}[-]\d{4}$/}
+
+  extend ActiveHash::Associations::ActiveRecordExtensions
+  belongs_to_active_hash :prefecture
+
+  validates :prefecture_id, prefecture: true
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,0 +1,20 @@
+class Prefecture < ActiveHash::Base
+  self.data = [
+      {id: 1, name: '北海道'}, {id: 2, name: '青森県'}, {id: 3, name: '岩手県'},
+      {id: 4, name: '宮城県'}, {id: 5, name: '秋田県'}, {id: 6, name: '山形県'},
+      {id: 7, name: '福島県'}, {id: 8, name: '茨城県'}, {id: 9, name: '栃木県'},
+      {id: 10, name: '群馬県'}, {id: 11, name: '埼玉県'}, {id: 12, name: '千葉県'},
+      {id: 13, name: '東京都'}, {id: 14, name: '神奈川県'}, {id: 15, name: '新潟県'},
+      {id: 16, name: '富山県'}, {id: 17, name: '石川県'}, {id: 18, name: '福井県'},
+      {id: 19, name: '山梨県'}, {id: 20, name: '長野県'}, {id: 21, name: '岐阜県'},
+      {id: 22, name: '静岡県'}, {id: 23, name: '愛知県'}, {id: 24, name: '三重県'},
+      {id: 25, name: '滋賀県'}, {id: 26, name: '京都府'}, {id: 27, name: '大阪府'},
+      {id: 28, name: '兵庫県'}, {id: 29, name: '奈良県'}, {id: 30, name: '和歌山県'},
+      {id: 31, name: '鳥取県'}, {id: 32, name: '島根県'}, {id: 33, name: '岡山県'},
+      {id: 34, name: '広島県'}, {id: 35, name: '山口県'}, {id: 36, name: '徳島県'},
+      {id: 37, name: '香川県'}, {id: 38, name: '愛媛県'}, {id: 39, name: '高知県'},
+      {id: 40, name: '福岡県'}, {id: 41, name: '佐賀県'}, {id: 42, name: '長崎県'},
+      {id: 43, name: '熊本県'}, {id: 44, name: '大分県'}, {id: 45, name: '宮崎県'},
+      {id: 46, name: '鹿児島県'}, {id: 47, name: '沖縄県'}
+  ]
+end

--- a/app/views/delivery_address/index.html.haml
+++ b/app/views/delivery_address/index.html.haml
@@ -1,0 +1,75 @@
+.delivery_address-wrapper
+
+  .delivery_address-header
+    = link_to root_path do
+      = image_tag("logo.png", width: "200px")
+
+  .delivery_address-main
+    %section.delivery_address-container
+      %h2.delivery_address-head
+        商品送付先入力
+      = form_with model: @user, url:"", class:"delivery_address-form", local: true do |f|
+        .delivery_address-content
+          .delivery_address-label
+            = f.label "お名前(全角)", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          .delivery_address-name
+            = f.text_field :delivery_family_name, class: "delivery_address-input-default left-side", placeholder: "例)田中"
+            = f.text_field :delivery_first_name, class: "delivery_address-input-default right-side", placeholder: "例)花子"
+
+          .delivery_address-label
+            = f.label "お名前カナ(全角)", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          .delivery_address-name
+            = f.text_field :delivery_family_name_kana, class: "delivery_address-input-default left-side", placeholder: "例)タナカ"
+            = f.text_field :delivery_first_name_kana, class: "delivery_address-input-default right-side", placeholder: "例)ハナコ"
+
+          .delivery_address-label
+            = f.label "郵便番号", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          = f.text_field :"post_code", class: "delivery_address-input-default", placeholder: "例)123-4567"
+          .delivery_address-label
+            = f.label "都道府県", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "選択ください"
+          .delivery_address-label
+            = f.label "市区町村", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          = f.text_field :"city", class: "delivery_address-input-default", placeholder: "例)渋谷区"
+          .delivery_address-label
+            = f.label "番地", class: "addlress-form-label"
+            %span.delivery_address-require
+              必須
+          = f.text_field :"home_number", class: "delivery_address-input-default", placeholder: "例)円山町1-1-1"
+          .delivery_address-label
+            = f.label "建物名", class: "addlress-form-labe"
+            %span.delivery_address-require__optionall
+              任意
+          = f.text_field :"building_name", class: "delivery_address-input-default", placeholder: "例)青山ビル101"
+          .delivery_address-label
+            = f.label "電話", class: "addlress-form-labe"
+            %span.delivery_address-require__optionall
+              任意
+          = f.text_field :"phone_number", class: "delivery_address-input-default", placeholder: "例)09012345678"
+
+          = f.submit "ユーザー登録", class: "user_registration-btn"
+
+  .registration-footer
+    .terms
+      %ul.terms__list
+        %li.terms__list__privacy_policy
+          = link_to "プライバシーポリシー", "#", class: "terms-link"
+        %li.terms__list__of_use
+          = link_to "フリマ利用規約", "#", class: "terms-link"
+        %li.terms__list__law
+          = link_to "特定商取引に関する表記", "#", class: "terms-link"
+
+    = link_to root_path do
+      = image_tag("point-logo.png", class: "footer-logo")
+    %P.company-inc
+      © FURIMA, Inc.

--- a/app/views/devise/registrations/sns.html.haml
+++ b/app/views/devise/registrations/sns.html.haml
@@ -31,17 +31,17 @@
 -#               %a{href: "#", class: "signup-form__info-text__link"}プライバシーポリシー
 -#               に同意したものとみなされます。
 
-  -# .singup-footer
-  -#   .terms
-  -#     %ul.terms__list
-  -#       %li.terms__list__privacy_policy
-  -#         = link_to "プライバシーポリシー", "#", class: "terms-link"
-  -#       %li.terms__list__of_use
-  -#         = link_to "フリマ利用規約", "#", class: "terms-link"
-  -#       %li.terms__list__law
-  -#         = link_to "特定商取引に関する表記", "#", class: "terms-link"
+-#   .singup-footer
+-#     .terms
+-#       %ul.terms__list
+-#         %li.terms__list__privacy_policy
+-#           = link_to "プライバシーポリシー", "#", class: "terms-link"
+-#         %li.terms__list__of_use
+-#           = link_to "フリマ利用規約", "#", class: "terms-link"
+-#         %li.terms__list__law
+-#           = link_to "特定商取引に関する表記", "#", class: "terms-link"
 
-  -#   = link_to root_path do
-  -#     = image_tag("point-logo.png", class: "footer-logo")
-  -#   %P.company-inc
-  -#     © FURIMA, Inc.
+-#     = link_to root_path do
+-#       = image_tag("point-logo.png", class: "footer-logo")
+-#     %P.company-inc
+-#       © FURIMA, Inc.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,5 @@ Rails.application.routes.draw do
   resources :mypages, only: :index
   resources :cards, only: [:index, :new]
   resources :logs, only: :index
+  resources :delivery_address, only: :index
 end

--- a/db/migrate/20200730081552_create_delivery_addresses.rb
+++ b/db/migrate/20200730081552_create_delivery_addresses.rb
@@ -1,0 +1,18 @@
+class CreateDeliveryAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :delivery_addresses do |t|
+      t.string :delivery_family_name,       null: false
+      t.string :delivery_first_name,        null: false
+      t.string :delivery_family_name_kana,  null: false
+      t.string :delivery_first_name_kana,   null: false
+      t.integer :post_code,                 null: false
+      t.integer :prefecture_id,             null: false
+      t.string :city,                       null: false
+      t.string :home_number,                null: false
+      t.string :building_name
+      t.integer :phone_number,              unique: true
+      t.references :user,                null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,24 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_28_021626) do
+ActiveRecord::Schema.define(version: 2020_07_30_081552) do
+
+  create_table "delivery_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "delivery_family_name", null: false
+    t.string "delivery_first_name", null: false
+    t.string "delivery_family_name_kana", null: false
+    t.string "delivery_first_name_kana", null: false
+    t.integer "post_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "home_number", null: false
+    t.string "building_name"
+    t.integer "phone_number"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_delivery_addresses_on_user_id"
+  end
 
   create_table "details", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false
@@ -30,4 +47,5 @@ ActiveRecord::Schema.define(version: 2020_07_28_021626) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "delivery_addresses", "users"
 end

--- a/test/controllers/delivery_address_controller_test.rb
+++ b/test/controllers/delivery_address_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeliveryAddressControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/delivery_addresses.yml
+++ b/test/fixtures/delivery_addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/delivery_address_test.rb
+++ b/test/models/delivery_address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class DeliveryAddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
ユーザー登録時に必須となる住所情報のテーブル作成
ユーザー登録時にウィザード形式を導入するためのマークアップ
active_hashでの都道府県モデル作成
# why
住所情報は、ユーザー登録時に必須となるため。
active_hashでの都道府県モデル作成はitemsでも使用するため
ウィザード形式にて使用するviewの仮作成で作成した、delivery_addressの不要箇所は後ほど削除(index, controller, routes)