### PR TITLE
エラー文の修正

### DIFF
--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -6,11 +6,11 @@ class DeliveryAddress < ApplicationRecord
   # 同じ電話番号は登録できない
   validates :phone_number, uniqueness: true
   # 名前 全角文字のみ登録可能
-  validates :delivery_family_name, :delivery_first_name, format: {with:/\A[ぁ-んァ-ン一-龥]/}
+  validates :delivery_family_name, :delivery_first_name, format: {with:/\A[ぁ-んァ-ン一-龥]/, message: "は全角のみで入力して下さい"}
   # 名前よみがな 全角カタカナにみ登録可能
-  validates :delivery_family_name_kana, :delivery_first_name_kana, format: {with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナのみで入力して下さい"}
+  validates :delivery_family_name_kana, :delivery_first_name_kana, format: {with: /\A[\p{katakana} ー－&&[^ -~｡-ﾟ]]+\z/, message: "は全角カタカナのみで入力して下さい"}
   # 郵便番号 ハイフン抜きの7桁のみ登録可能
-  validates :post_code, format: {with: /\A\d{7}\z/}
+  validates :post_code, format: {with: /\A\d{7}\z/, message: "は「-」を除いて記入してください"}
 
 
   extend ActiveHash::Associations::ActiveRecordExtensions

--- a/app/views/devise/registrations/new_delivery_address.html.haml
+++ b/app/views/devise/registrations/new_delivery_address.html.haml
@@ -9,7 +9,7 @@
       %h2.delivery_address-head
         商品送付先入力
       = form_with model: @address, url: addresses_path,method: :post, class:"delivery_address-form", local: true do |f|
-        = render "delivery_error_messages", resource: resource
+
         .delivery_address-content
           .delivery_address-label
             = f.label "お名前(全角)", class: "addlress-form-label"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       user: ユーザー
+      delivery_address: 届け先住所
     attributes:
       user:
         nickname: ニックネーム
@@ -13,6 +14,15 @@ ja:
         first_name: 名
         family_name_kana: 性カナ
         first_name_kana: 名カナ
+      delivery_address:
+        delivery_family_name: 性
+        delivery_first_name: 名
+        delivery_family_name_kana: 性カナ
+        delivery_first_name_kana: 名カナ
+        post_code: 郵便番号
+        phone_number: 電話番号
+        city: 市区町村
+        home_number: 番地
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -76,6 +76,11 @@ ActiveRecord::Schema.define(version: 2020_08_06_055313) do
     t.string "nickname", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
+    t.string "family_name", null: false
+    t.string "first_name", null: false
+    t.string "family_name_kana", null: false
+    t.string "first_name_kana", null: false
+    t.date "birthdate", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
# what
届先住所登録に表示するエラー文を日本語に修正し、整える

# why
エラー文の表示の中に、カラム名と日本語が混在していたから