### PR TITLE
購入確認画面の修正

### DIFF
--- a/app/views/confirms/index.html.haml
+++ b/app/views/confirms/index.html.haml
@@ -74,6 +74,10 @@
             %br
             TEL：
             = @address.phone_number
+            %br
+            名前：
+            = @address.delivery_family_name
+            = @address.delivery_first_name
         -# 実装完了後コメントアウト解除
         -# = link_to "", class: "select__registration" do
         -#   = icon("fas", "plus-circle", class: "select__registration__icon")


### PR DESCRIPTION
# what
購入画面の届け先に名前を追加

# why
届け先の名前の表示が抜けていたため。