### PR TITLE
電話番号のバリデーション修正

### DIFF
--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -4,7 +4,7 @@ class DeliveryAddress < ApplicationRecord
   # 空の入力を防ぐ
   validates :delivery_family_name, :delivery_first_name, :delivery_family_name_kana, :delivery_first_name_kana, :post_code, :city, :home_number, presence: true
   # 同じ電話番号は登録できない
-  validates :phone_number, uniqueness: true
+  validates :phone_number, uniqueness: true, allow_blank: true
   # 名前 全角文字のみ登録可能
   validates :delivery_family_name, :delivery_first_name, format: {with:/\A[ぁ-んァ-ン一-龥]/, message: "は全角のみで入力して下さい"}
   # 名前よみがな 全角カタカナにみ登録可能


### PR DESCRIPTION
# what
任意の電話番号が空の場合、uniqueness: trueが働き複数のユーザー登録ができなかった。
allow_blank: trueを記述し空の場合は登録できるようにした。

# why
電話番号は任意登録のため、未記入でも登録できるように処理
