### PR TITLE
未ログイン時に商品出品ができないよう調整

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, only: :new
   before_action :move_to_index_destroy, only: [:destroy]
 
   def index


### PR DESCRIPTION
## What
未ログイン状態で/items/newのパスを直接入力すると新規登録・ログイン画面に移動するよう設定

## Why
ユーザー登録している人のみが出品できるようにするため
