### PR TITLE
商品登録失敗時の挙動修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,7 +29,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
-      render :new
+      redirect_to action: 'new'
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -24,6 +24,7 @@ class ItemsController < ApplicationController
   end
 
   def create
+    @category_parent_array = Category.where(ancestry: nil)
     @item = Item.new(item_params)
     if @item.save
       redirect_to root_path

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,6 +29,7 @@ class ItemsController < ApplicationController
     if @item.save
       redirect_to root_path
     else
+      flash[:alert] = '必須項目を入力してください'
       redirect_to action: 'new'
     end
   end


### PR DESCRIPTION
## What
商品出品ページにて、登録に失敗したときの挙動を修正

## Why
登録失敗→再度登録時にページ表示でエラーが出ることがあったため