### PR TITLE
itemsテーブルのstatusカラムの削除

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,13 +11,8 @@ class Item < ApplicationRecord
 
   accepts_nested_attributes_for :item_images, allow_destroy: true
 
-  enum status: {
-    sale: 1,
-    sold: 2
-  }
-
   validates :name, length: { maximum: 40 }, presence: true
   validates :explanation, length: { maximum: 1000 }, presence: true
-  validates :status, :category_id, :condition_id, :postage_id, :prefecture_id, :prepare_id, :seller_id, presence: true
+  validates :category_id, :condition_id, :postage_id, :prefecture_id, :prepare_id, :seller_id, presence: true
   validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }, presence: true
 end

--- a/db/migrate/20200811161043_remove_status_from_items.rb
+++ b/db/migrate/20200811161043_remove_status_from_items.rb
@@ -1,5 +1,0 @@
-class RemoveStatusFromItems < ActiveRecord::Migration[6.0]
-  def change
-    remove_column :items, :status, :integer
-  end
-end

--- a/db/migrate/20200811161043_remove_status_from_items.rb
+++ b/db/migrate/20200811161043_remove_status_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromItems < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :items, :status, :integer
+  end
+end

--- a/db/migrate/20200812054122_remove_status_from_items.rb
+++ b/db/migrate/20200812054122_remove_status_from_items.rb
@@ -1,0 +1,5 @@
+class RemoveStatusFromItems < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :items, :status, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_11_161043) do
+ActiveRecord::Schema.define(version: 2020_08_08_074001) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -71,6 +71,7 @@ ActiveRecord::Schema.define(version: 2020_08_11_161043) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "status", default: 1, null: false
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_08_074001) do
+ActiveRecord::Schema.define(version: 2020_08_12_054122) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -71,7 +71,6 @@ ActiveRecord::Schema.define(version: 2020_08_08_074001) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status", default: 1, null: false
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_08_074001) do
+ActiveRecord::Schema.define(version: 2020_08_11_161043) do
 
   create_table "cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
@@ -71,7 +71,6 @@ ActiveRecord::Schema.define(version: 2020_08_08_074001) do
     t.integer "price", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.integer "status", default: 1, null: false
     t.bigint "seller_id", null: false
     t.bigint "buyer_id"
     t.index ["buyer_id"], name: "index_items_on_buyer_id"

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
   factory :item do
     name {"editテスト"}
     explanation {"食べ物の紹介"}
-    status {"sale"}
     category_id {"400"}
     condition_id {"1"}
     postage_id {"2"}

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -32,12 +32,6 @@ describe Item, type: :model do
       expect(item.errors[:explanation]).to include("は1000文字以内で入力してください")
     end
 
-    it "is invalid without a status" do
-      item = build(:item, status: "")
-      item.valid?
-      expect(item.errors[:status]).to include("を入力してください")
-    end
-
     it "is invalid without a category_id" do
       item = build(:item, category_id: "")
       item.valid?


### PR DESCRIPTION
## What
itemsテーブルのstatusカラムを削除

## Why
seller_idとbuyer_idの2つがあれば、statusカラムは必要なかったため