### PR TITLE
購入画面・カード削除機能

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -38,7 +38,7 @@ class CardsController < ApplicationController
       customer.delete
       @card.delete
     end
-      redirect_to cards_path
+    redirect_to cards_path
   end
 
   def show #Cardのデータpayjpに送り情報を取り出します

--- a/app/controllers/confirms_controller.rb
+++ b/app/controllers/confirms_controller.rb
@@ -5,7 +5,8 @@ class ConfirmsController < ApplicationController
   def index
     @user = current_user
     @address = DeliveryAddress.find_by(user_id: current_user.id)
-
+    
+    
     if @card.blank?
       #登録された情報がない場合にカード登録画面に移動
       redirect_to new_card_path
@@ -25,7 +26,7 @@ class ConfirmsController < ApplicationController
       customer: @card.customer_id, #顧客ID
       currency: 'jpy', #日本円
     )
-    @item_buyer = Item.find_by(params[:id])
+    @item_buyer = Item.find(params[:item_id])
     @item_buyer.update(buyer_id: current_user.id)
     redirect_to done_item_confirms_path
   end
@@ -40,7 +41,7 @@ class ConfirmsController < ApplicationController
   end
 
   def set_item
-    @item = Item.find_by(params[:id])
+    @item = Item.find(params[:item_id])
   end
 
 end

--- a/app/controllers/confirms_controller.rb
+++ b/app/controllers/confirms_controller.rb
@@ -26,8 +26,7 @@ class ConfirmsController < ApplicationController
       customer: @card.customer_id, #顧客ID
       currency: 'jpy', #日本円
     )
-    @item_buyer = Item.find(params[:item_id])
-    @item_buyer.update(buyer_id: current_user.id)
+    @item.update(buyer_id: current_user.id)
     redirect_to done_item_confirms_path
   end
 

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -7,5 +7,5 @@
     - exp_month = @default_card_information.exp_month.to_s
     - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
     = exp_month + " / " + exp_year
-    = form_with url: delete_cards_path, method: :post, id: 'charge-form',  name: "inputForm" do |f|
+    = form_with url: delete_cards_path, method: :post, id: 'charge-form', name: "inputForm", local: true do |f|
       = f.submit "削除する", class: 'card-delete-btn'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -75,7 +75,7 @@
           .buyerBox
             - if @item.buyer_id.present?
               .buyer__btn
-                ※購入済み         
+                ※購入済み
             - elsif current_user.id != @item.seller_id
               = link_to "購入する", item_confirms_path(@item), class: "buyer__btn"
             -else

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -73,11 +73,11 @@
                 = link_to "この商品を削除する", item_path, method: :delete, class: "inappropriate__word", data: { confirm: '【確認】削除すると二度と復活できません。本当に削除しますか？' }
         -if user_signed_in?
           .buyerBox
-            -if current_user.id != @item.seller_id
-              = link_to "購入する", item_confirms_path(@item), class: "buyer__btn"
-            - elsif @item.buyer_id.present?
+            - if @item.buyer_id.present?
               .buyer__btn
-                ※この商品は既に購入されております
+                ※購入済み         
+            - elsif current_user.id != @item.seller_id
+              = link_to "購入する", item_confirms_path(@item), class: "buyer__btn"
             -else
               .buyer__btn
                 自分の投稿です


### PR DESCRIPTION
# what
- 購入画面が全て同じ商品を選択してしまう箇所を修正
- クレジットカードを削除した際、ページが推移しない箇所を修正

# why
- 現状だと希望の商品が購入できないので修正
- クレジットカードを削除してもページが推移しなく、削除できたか分かり辛かったため修正